### PR TITLE
Bugfix attempt 1: useCallback

### DIFF
--- a/src/context/UIContext/UIContextProvider.tsx
+++ b/src/context/UIContext/UIContextProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { UIContext, UIContextType } from './UIContext';
 import { DateTime } from 'luxon';
 
@@ -19,9 +19,13 @@ export const UIContextProvider = (props: UIContextProviderProps) => {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const toggleModal = () => {
-    setIsModalOpen(!isModalOpen);
-  };
+  /*
+    The callback is memoized, which means that the same reference will be returned each time.
+    This means that when React will compare this function to the function passed in the previous rerender, they will be equal (referential equality will pass).
+  */
+  const toggleModal = useCallback(() => {
+    setIsModalOpen((isModalOpen) => !isModalOpen);
+  }, []);
 
   const context: UIContextType = {
     dateNow: dateNow,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
 import { HomeModal } from '../components/Home/HomeModal';
 import { useUIContext } from '../context/UIContext/UIContext';
 
 export const Home = () => {
   const { isModalOpen, toggleModal } = useUIContext();
+
+  /* 
+    HomeModal is still being rerendered, because a change in the context triggers a rerender in every subscribed component
+    When a component rerenders, this also triggers a rerender of all of it's children. 
+    This is why HomeModal rerenders, despite the fact that it's props are still the same. 
+  */
   return (
     <div className="Home">
       <HomeModal isModalOpen={isModalOpen} toggleModal={toggleModal} />


### PR DESCRIPTION
`toggleModal` is a basic function, declared in the `UIContext`. This means that it is recreated on each rerender.
We memoize the `toggleModal` function, which means that the same reference will be returned each rerender.

This doesn't fix the rerender issue, because each time the context value changes, all subscriber components rerender. In React, when a component rerenders, all children of that component also rerender (and so on, recursively in a hierarchical manner, all of them rerender). Because `HomeModal` is a child of `Home` component (which is subscribed to the `UIContext`), it will rerender each time `Home` rerenders (despite the fact that it's props haven't changed!), and `Home` rerenders each time `UIContext` rerenders (which is each second).