### PR TITLE
Bugfix attempt 2: memo

### DIFF
--- a/src/components/Home/HomeModal.tsx
+++ b/src/components/Home/HomeModal.tsx
@@ -6,7 +6,14 @@ interface IHomeModal {
   toggleModal: () => void;
 }
 
-export const HomeModal = (props: IHomeModal) => {
+/*
+  Memoizing the component means that React will remember value of props of the component.
+  Upon next rerender, it will compare the value of the current props to the value of the remembered props in the previous rerender.
+  If the props are the same, it will skip the rerender. This means that the rerender function will not be ran, which in turn means that no child rerenders will be ran either.
+  In this case this doesn't work though, because toggleModal has a different reference on each rerender, and React by default compares props by references (you can define a custom comparison function though).
+  This means that the previous props never equal current props, so component is rerendered each time, making memo useless.  
+*/
+export const HomeModal = React.memo((props: IHomeModal) => {
   console.log('HomeModal render');
   return (
     <div className="HomeModal">
@@ -23,4 +30,4 @@ export const HomeModal = (props: IHomeModal) => {
       </Modal>
     </div>
   );
-};
+});


### PR DESCRIPTION
We memoize `HomeModal` component by wrapping it in `React.memo`.
 
Memoizing the component means that React will remember value of props of the component. Upon next rerender, it will compare the value of the current props to the value of the remembered props in the previous rerender. If the props are the same, it will skip the rerender. This means that the rerender function will not be ran, which in turn means that no child rerenders will be ran either.

Seems like this should work in this case - `HomeModal` accepts two props - `isModalOpen` and `toggleModal`. None of them change when `dateNow` changes in `UIContext`. But that is not actually true. State variable `isModalOpen` indeed doesn't change, but `toggleModal` does, because it is defined as a variable inside the context provider.
 
This means that `toggleModal` has a different reference on each rerender, and `React.memo` by default compares props by references (you can define a custom comparison function though). This means that the previous props never equal current props in `HomeModal`, so the component is rerendered each time, making memo useless. 