### PR TITLE
 Bugfix attempt 3: React.memo + useCallback

### DIFF
--- a/src/components/Home/HomeModal.tsx
+++ b/src/components/Home/HomeModal.tsx
@@ -6,7 +6,8 @@ interface IHomeModal {
   toggleModal: () => void;
 }
 
-export const HomeModal = (props: IHomeModal) => {
+// this time, memo successfuly prevents component from rerendering because toggleModal doesn't change between rerenders.
+export const HomeModal = React.memo((props: IHomeModal) => {
   console.log('HomeModal render');
   return (
     <div className="HomeModal">
@@ -23,4 +24,4 @@ export const HomeModal = (props: IHomeModal) => {
       </Modal>
     </div>
   );
-};
+});

--- a/src/context/UIContext/UIContextProvider.tsx
+++ b/src/context/UIContext/UIContextProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { UIContext, UIContextType } from './UIContext';
 import { DateTime } from 'luxon';
 
@@ -19,9 +19,9 @@ export const UIContextProvider = (props: UIContextProviderProps) => {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const toggleModal = () => {
-    setIsModalOpen(!isModalOpen);
-  };
+  const toggleModal = useCallback(() => {
+    setIsModalOpen((isModalOpen) => !isModalOpen);
+  }, []);
 
   const context: UIContextType = {
     dateNow: dateNow,


### PR DESCRIPTION
Based on previous attempts at solving the rerendering issue (#1 and #2) we can see the following:
1) `useCallback` makes sure that `toggleModal` is the same through each rerender, but `HomeModal` is rerendered regardless because of how React rerendering works - when a parent (`Home`) rerenders (which is each time the context changes), all children (`HomeModal`) rerender even if their props stay the same.
2) `memo` makes sure that if no props change in the component, it doesn't rerender the component. The issue is however that `toggleModal` changes each render and thus the equality by reference fails.

So what's the solution? Combination of approaches 1 and 2. Now `toggleModal` is memoized and doesn't change after each rerender, while `HomeModal` doesn't rerender because it's props stay the same on each rerender (except when the modal opens / closes and `isModalOpen` changes - but that is okay).

To sum up, we can see from this example that `memo` can help us skip rerenders of the component. It is especially useful if a component rerenders with same props many times. However, memo cannot work if all functions that are passed in aren't memoized, because their reference changes on each rerender. A similar thing occurs when we pass a computed non-state variable to the component - we can memoize such variables using `useMemo`.

Is `React.memo` worth it? Obviously there is some overhead in both `useCallback` and `React.memo`, since they need to remember all props. I think it is worth it when a component's rerender is very expensive - either it has a very expensive render function or it has many children that will all be rerendered. Using `React.memo` we can not only prevent the parent from rerendering, but all of it's children as well.

In this particular case using `React.memo` is probably not worth it, since `HomeModal` is not a very heavy component. But of course this is a very simplified example. In practice, it's best to use profiling tools to measure performance benefits of a memoized component.